### PR TITLE
Fix Kubernetes CrashLoopBackOff issue

### DIFF
--- a/charts/spark-hs/templates/deployment.yaml
+++ b/charts/spark-hs/templates/deployment.yaml
@@ -39,6 +39,8 @@ spec:
           env:
             - name: SPARK_CONF_DIR
               value: /opt/spark/conf
+            - name: SPARK_NO_DAEMONIZE
+              value: "false"
           {{- with .Values.env }}
               {{- toYaml . | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
First, good work on this.

However, I encountered an issue that the deployment kept crashing with a `CrashLoopBackOff` error.

Turned out that the history server script sends the process in the background by default, hence the process exists and the container thinks it's done.

Setting SPARK_NO_DAEMONIZE=false fixes that.cx

I'm using Spark 3.4.1 but I think it may happen on lower versions too.

See https://stackoverflow.com/questions/75699723/what-could-cause-my-spark-history-server-start-but-then-pod-is-completed-immedia for details.